### PR TITLE
Added create a wishlist

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -42,5 +42,55 @@ def index():
 ######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################
-
 # Todo: Place your REST API code here ...
+
+
+######################################################################
+# CREATE A NEW WISHLIST
+######################################################################
+@app.route("/wishlists", methods=["POST"])
+def create_wishlists():
+    """
+    Creates a Wishlist
+    This endpoint will create a Wishlist based on the JSON body provided
+    """
+    app.logger.info("Request to create a Wishlist")
+    check_content_type("application/json")
+
+    # Create the wishlist
+    wishlist = Wishlist()
+    wishlist.deserialize(request.get_json())
+    wishlist.create()
+
+    # Create a message to return
+    message = wishlist.serialize()
+
+    # Todo: uncomment this code when get_wishlists is implemented
+    # location_url = url_for("get_wishlists", wishlist_id=wishlist.id, _external=True)
+    location_url = "unknown"
+
+    app.logger.info("Wishlist with id [%s] created.", wishlist.id)
+    return jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
+
+
+######################################################################
+#  U T I L I T Y   F U N C T I O N S
+######################################################################
+
+
+def check_content_type(content_type):
+    """Checks that the media type is correct"""
+    if "Content-Type" not in request.headers:
+        app.logger.error("No Content-Type specified.")
+        abort(
+            status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            f"Content-Type must be {content_type}",
+        )
+
+    if request.headers["Content-Type"] == content_type:
+        return
+
+    app.logger.error("Invalid Content-Type: %s", request.headers["Content-Type"])
+    abort(
+        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, f"Content-Type must be {content_type}"
+    )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -28,6 +28,7 @@ from service.models import db, Wishlist
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
 )
+BASE_URL = "/wishlists"
 
 
 ######################################################################
@@ -69,5 +70,105 @@ class TestWishlistService(TestCase):
         """It should call the home page"""
         resp = self.client.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    ######################################################################
+    #  H E L P E R   M E T H O D S
+    ######################################################################
+
+    def _create_wishlists(self, count):
+        """Factory method to create wishlists in bulk"""
+        wishlists = []
+        for _ in range(count):
+            wishlist = WishlistFactory()
+            resp = self.client.post(BASE_URL, json=wishlist.serialize())
+            self.assertEqual(
+                resp.status_code,
+                status.HTTP_201_CREATED,
+                "Could not create test Wishlist",
+            )
+            new_wishlist = resp.get_json()
+            wishlist.id = new_wishlist["id"]
+            wishlists.append(wishlist)
+        return wishlists
+
+    ######################################################################
+    #  W I S H L I S T   T E S T   C A S E S
+    ######################################################################
+
+    def test_create_wishlist(self):
+        """It should Create a new Wishlist"""
+        wishlist = WishlistFactory()
+        resp = self.client.post(
+            BASE_URL, json=wishlist.serialize(), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Make sure location header is set
+        location = resp.headers.get("Location", None)
+        self.assertIsNotNone(location)
+
+        # Check the data is correct
+        new_wishlist = resp.get_json()
+        self.assertEqual(
+            new_wishlist["customer_id"],
+            wishlist.customer_id,
+            "Customer IDs do not match",
+        )
+        self.assertEqual(new_wishlist["name"], wishlist.name, "Names do not match")
+        self.assertEqual(
+            new_wishlist["description"],
+            wishlist.description,
+            "Descriptions do not match",
+        )
+        self.assertEqual(new_wishlist["items"], wishlist.items, "Items do not match")
+
+        # Todo: Uncomment this code when get_wishlists is implemented
+
+        # # Check that the location header was correct by getting it
+        # resp = self.client.get(location, content_type="application/json")
+        # self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        # new_wishlist = resp.get_json()
+        # self.assertEqual(
+        #     new_wishlist["customer_id"],
+        #     wishlist.customer_id,
+        #     "Customer IDs do not match",
+        # )
+        # self.assertEqual(new_wishlist["name"], wishlist.name, "Names do not match")
+        # self.assertEqual(
+        #     new_wishlist["description"],
+        #     wishlist.description,
+        #     "Descriptions do not match",
+        # )
+        # self.assertEqual(new_wishlist["items"], wishlist.items, "Items do not match")
+
+    def test_create_wishlist_bad_payload(self):
+        """It should fail with 400 BAD_REQUEST when request body is missing required fields"""
+        resp = self.client.post(
+            "/wishlists",
+            json={"description": "only desc"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        data = resp.get_json()
+        self.assertEqual(data["status"], status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Bad Request", data["error"])
+
+    def test_create_wishlist_method_not_allowed(self):
+        """It should return 405 METHOD_NOT_ALLOWED when using an unsupported HTTP method"""
+        resp = self.client.put("/wishlists", json={})
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        data = resp.get_json()
+        self.assertEqual(data["status"], status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_create_wishlist_wrong_content_type(self):
+        """It should fail with 415 UNSUPPORTED_MEDIA_TYPE when Content-Type is not application/json"""
+        resp = self.client.post("/wishlists", data="{}", content_type="text/html")
+        self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+        data = resp.get_json()
+        self.assertEqual(data["status"], status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
+    ######################################################################
+    #  I T E M   T E S T   C A S E S
+    ######################################################################
 
     # Todo: Add your test cases here...

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -253,7 +253,7 @@ class TestWishlist(TestCase):
 
     def test_wishlist_update_without_id_raises(self):
         """Wishlist.update should fail when id is empty (PersistentBase.update)"""
-        wl = Wishlist()  # 没有持久化，id 为空
+        wl = Wishlist()
         with self.assertRaises(DataValidationError) as ctx:
-            wl.update()  # 走到 raise DataValidationError("Update called with empty ID field")
+            wl.update()
         self.assertIn("empty ID field", str(ctx.exception))


### PR DESCRIPTION
Made the following changes:
* Implemented POST /wishlists endpoint to create a new wishlist
* Added unit tests for wishlist creation, covering:
  * Successful creation (201 Created)
  * Missing required fields (400 Bad Request)
  * Unsupported HTTP method (405 Method Not Allowed)
  * Invalid content type (415 Unsupported Media Type)

Uncomment code (test_routes.py 127-142)(routes.py 69) when get_wishlists is implemented