### PR TITLE
added clear wishlist

### DIFF
--- a/service/models/wishlist.py
+++ b/service/models/wishlist.py
@@ -147,3 +147,16 @@ class Wishlist(db.Model, PersistentBase):
         """Returns all Wishlists owned by a given customer"""
         logger.info("Processing customer query for %s ...", customer_id)
         return cls.query.filter(cls.customer_id == customer_id)
+
+    def clear_items(self) -> int:
+        """
+        Clear all Items under this Wishlist.
+        Idempotent: if there are no items, it still succeeds (deleting 0 rows).
+        Returns:
+            int: number of deleted rows (for logging/metrics).
+        """
+        deleted = Item.query.filter_by(wishlist_id=self.id).delete(
+            synchronize_session=False
+        )
+        db.session.commit()
+        return deleted

--- a/service/routes.py
+++ b/service/routes.py
@@ -418,6 +418,35 @@ def update_wishlists(wishlist_id: int):
     return jsonify(wishlist.serialize()), status.HTTP_200_OK
 
 
+#################################################################
+# CLEAR A WISHLIST
+#################################################################
+@app.route("/wishlists/<int:wishlist_id>/clear", methods=["PUT"])
+def clear_wishlist(wishlist_id: int):
+    """
+    Clear all items in the given Wishlist (idempotent).
+    Responses:
+        204 No Content: wishlist cleared successfully (even if it was already empty)
+        404 Not Found : wishlist does not exist
+    """
+    app.logger.info("Request to clear all items in Wishlist [%s]", wishlist_id)
+
+    wishlist = Wishlist.find(wishlist_id)
+    if not wishlist:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Wishlist with id '{wishlist_id}' was not found.",
+        )
+
+    deleted = wishlist.clear_items()  # domain method commits the transaction
+    app.logger.info(
+        "Cleared %s item(s) from Wishlist [%s] (idempotent 204).",
+        deleted,
+        wishlist_id,
+    )
+    return "", status.HTTP_204_NO_CONTENT
+
+
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################


### PR DESCRIPTION
Added a new endpoint to clear all items within a specific wishlist without deleting the wishlist itself
* Model
    * Added domain method to remove all items under a wishlist in a single transaction.
    * Ensures idempotent behavior deleting 0 items is still considered successful.
* Routes
    * Added new endpoint PUT /wishlists/{wishlist_id}/clear
    * Returns:
	   * 404 Not Found if wishlist does not exist
	   * 204 No Content on success (even if empty)
* Tests
    * Added test cases covering all acceptance scenarios:
	* Clear wishlist with items → 204 + empty list
	* Clear already empty wishlist → 204 (idempotent)
	* Clear non-existent wishlist → 404
