### PR TITLE
added create local k3s

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -80,7 +80,9 @@
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "28.5.1"
+		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {}
 	}
 }


### PR DESCRIPTION
When creating the local K3s cluster inside the DevContainer, the command k3d cluster create nyu-devops --registry-create cluster-registry:0.0.0.0:5000

failed with the error:

error overwriting contents of /etc/hosts: Exec process in node failed with exit code '128' (broken pipe)

This happened because the Docker-in-Docker (dind) feature used in the DevContainer was outdated (version 28.3), and the internal Docker daemon did not have permission to modify /etc/hosts inside the node containers.

After upgrading the feature to version 28.5, the bug was fixed, and the cluster can now be created successfully.